### PR TITLE
Turn it into BitNet b1.58

### DIFF
--- a/bitnet_llama/modeling_llama.py
+++ b/bitnet_llama/modeling_llama.py
@@ -49,7 +49,8 @@ from transformers.utils import (
 )
 from transformers.models.llama.configuration_llama import LlamaConfig
 
-from bitnet_llama.module import BitLinearOptimized as BitLinear
+#from bitnet_llama.module import BitLinearOptimized as BitLinear
+from bitnet_llama.module import BitLinear as BitLinear
 
 
 if is_flash_attn_2_available():

--- a/bitnet_llama/module.py
+++ b/bitnet_llama/module.py
@@ -58,8 +58,8 @@ class BitLinear(nn.Linear):
         self.eps = 1e-5
 
     def ste_binarize(self, x):
-        # Apply the sign function for binarization
-        binarized_x = torch.sign(x)
+        # Apply the round-clip function for binarization
+        binarized_x = torch.max(-1, torch.min(1, torch.round(binarized_x)))
         # Use STE: during backward pass, we bypass the binarization
         binarized_x = (binarized_x - x).detach() + x
         return binarized_x
@@ -75,9 +75,9 @@ class BitLinear(nn.Linear):
             weight_group = self.weight[start_idx:end_idx]
 
             # Binarize each group using STE
-            alpha_g = weight_group.mean()
+            gamma_g = weight_group.abs().mean()
             binarized_weights[start_idx:end_idx] = self.ste_binarize(
-                weight_group - alpha_g
+                weight_group / (gamma_g + self.eps)
             )
 
         return binarized_weights

--- a/bitnet_llama/module.py
+++ b/bitnet_llama/module.py
@@ -59,7 +59,7 @@ class BitLinear(nn.Linear):
 
     def ste_binarize(self, x):
         # Apply the round-clip function for binarization
-        binarized_x = torch.max(-1, torch.min(1, torch.round(binarized_x)))
+        binarized_x = torch.max(-1, torch.min(1, torch.round(x)))
         # Use STE: during backward pass, we bypass the binarization
         binarized_x = (binarized_x - x).detach() + x
         return binarized_x

--- a/bitnet_llama/module.py
+++ b/bitnet_llama/module.py
@@ -59,7 +59,7 @@ class BitLinear(nn.Linear):
 
     def ste_binarize(self, x):
         # Apply the round-clip function for binarization
-        binarized_x = torch.max(-1, torch.min(1, torch.round(x)))
+        binarized_x = torch.max(torch.tensor(-1), torch.min(torch.tensor(1), torch.round(x)))
         # Use STE: during backward pass, we bypass the binarization
         binarized_x = (binarized_x - x).detach() + x
         return binarized_x

--- a/train_wikitext.sh
+++ b/train_wikitext.sh
@@ -1,5 +1,5 @@
 export CUDA_VISIBLE_DEVICES=0
-export WANDB_PROJECT=bitllama-wikitext
+export WANDB_PROJECT=bitllama-b158-wikitext
 
 python run_clm.py \
 --dataset_name='wikitext' \

--- a/train_wikitext.sh
+++ b/train_wikitext.sh
@@ -1,5 +1,5 @@
 export CUDA_VISIBLE_DEVICES=0
-export WANDB_PROJECT=bitllama-base-wikitext
+export WANDB_PROJECT=bitllama-b158-wikitext
 
 python run_clm.py \
 --dataset_name='wikitext' \

--- a/train_wikitext.sh
+++ b/train_wikitext.sh
@@ -1,5 +1,5 @@
 export CUDA_VISIBLE_DEVICES=0
-export WANDB_PROJECT=bitllama-b158-wikitext
+export WANDB_PROJECT=bitllama-base-wikitext
 
 python run_clm.py \
 --dataset_name='wikitext' \


### PR DESCRIPTION
Turn the vanilla BitNet implementation into BitNet b1.58.

Vanilla BitNet: https://arxiv.org/pdf/2310.11453.pdf
BitNet b1.58: https://arxiv.org/pdf/2402.17764.pdf

Loss log before the change:
<img width="326" alt="CleanShot 2024-03-02 at 20 27 35@2x" src="https://github.com/hideaki/BitNet-Transformers/assets/19518/13ec9a7c-d3f0-4345-bf54-e2b2fc5666a8">


Loss log after the change:
<img width="321" alt="CleanShot 2024-03-02 at 20 28 51@2x" src="https://github.com/hideaki/BitNet-Transformers/assets/19518/c0abf051-417d-4f38-9a22-ea387284e38a">


